### PR TITLE
Using same token on checkout to passthrough PR checks on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,7 @@ jobs:
         uses: 'actions/checkout@v2'
         with:
           ref: ${{ github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Node.js 16.x
         uses: actions/setup-node@v2

--- a/__tests__/.vib/vib-pipeline-2.json
+++ b/__tests__/.vib/vib-pipeline-2.json
@@ -35,10 +35,8 @@
         {
           "action_id": "trivy",
           "params": {
-            "config": {
-              "threshold": "CRITICAL",
-              "vuln_type": ["OS"]
-            }
+            "threshold": "CRITICAL",
+            "vuln_type": ["OS"]
           }
         }
       ]


### PR DESCRIPTION
With this change, the bump version step should not require PR checks.

Signed-off-by: Martin Perez <martinpe@vmware.com>