### PR TITLE
Add dist-check workflow

### DIFF
--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set Node.js 16.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: 16.x
 

--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -32,6 +32,13 @@ jobs:
         with:
           node-version: 16.x
 
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.npm
+          key: npm-${{ hashFiles('package-lock.json') }}
+          restore-keys: npm-
+
       - name: Install dependencies
         run: npm ci
 

--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -16,7 +16,9 @@ on:
     paths-ignore:
       - '**.md'
   workflow_dispatch:
+
 permissions:
+  contents: write
 
 jobs:
   check-dist:

--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -1,0 +1,53 @@
+# `dist/index.js` is a special file in Actions.
+# When you reference an action with `uses:` in a workflow,
+# `index.js` is the code that will run.
+# For our project, we generate this file through a build process
+# from other source files.
+# We need to make sure the checked-in `index.js` actually matches what we expect it to be.
+name: Check dist/
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+permissions:
+
+jobs:
+  check-dist:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set Node.js 16.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 16.x
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild the dist/ directory
+        run: npm run build-dist
+
+      - name: Compare the expected and actual dist/ directories
+        run: |
+          if [ "$(git diff --ignore-space-at-eol dist/ | wc -l)" -gt "0" ]; then
+            echo "Detected uncommitted changes after build.  See status below:"
+            git diff
+            exit 1
+          fi
+        id: diff
+
+      # If index.js was different than expected, upload the expected version as an artifact
+      - uses: actions/upload-artifact@v3
+        if: ${{ failure() && steps.diff.conclusion == 'failure' }}
+        with:
+          name: dist
+          path: dist/

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -1,15 +1,15 @@
 name: Validate
 on:
-  push: 
+  push:
     branches:
        - main
   pull_request:
     branches:
       - main
     types:
-      - assigned 
-      - opened 
-      - synchronize 
+      - assigned
+      - opened
+      - synchronize
       - reopened
 env:
   CSP_API_URL: https://console.cloud.vmware.com
@@ -78,6 +78,13 @@ jobs:
          uses: actions/setup-node@v2
          with:
            node-version: 16.x
+
+       - name: Cache dependencies
+         uses: actions/cache@v3
+         with:
+           path: ~/.npm
+           key: npm-${{ hashFiles('package-lock.json') }}
+           restore-keys: npm-
 
        - name: Install dependencies
          run: npm ci

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint src/**/*.ts",
     "package": "ncc build --source-map --license licenses.txt",
     "test": "jest --detectOpenHandles",
+    "build-dist": "npm run build && npm run package",
     "all": "npm run build && npm run format && npm run lint && npm run package && npm test"
   },
   "repository": {


### PR DESCRIPTION
Signed-off-by: Fran Mulero <fmulero@vmware.com>

### Description of the change
Follow the same approach as in https://github.com/actions/ with the `dist` folder. [Users has to maintain](https://github.com/actions/setup-node/pull/587) that folder and the workflow checks the content

### Additional information

Execution example: https://github.com/fmulero/vmware-image-builder-action/pull/1