### PR TITLE
Use VIB_ACTION_TOKEN to bypass branch protection rule

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,8 +6,6 @@ on:
         description: 'Release version (i.e. v1.2.3)'
         required: true
         type: string
-permissions:
-  contents: write
 jobs:
   release:
     name: Release Action
@@ -16,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Checkout Repository
+        with:
+          token: ${{ secrets.VIB_ACTION_TOKEN }}
 
       - name: Set Node.js 16.x
         uses: actions/setup-node@v2


### PR DESCRIPTION
@mpermar it turns out we need to use the `VIB_ACTION_TOKEN` in the end because of the branch protection rule that keeps anyone from pushing to `main`.